### PR TITLE
Fix if default ignores are empty.

### DIFF
--- a/ignores.go
+++ b/ignores.go
@@ -14,10 +14,13 @@ var (
 	VersionControlSystems = []string{".hg", ".git", ".svn", ".bzr"}
 )
 
-// Get retrieves a list of files to ignore in a given directory.
-// A set of default ignores may be given.
+// Get retrieves a list of paths to ignore in the directory the given ignore
+// file lives in. A set of default ignores may be given.
 func Get(path string, ignores ...string) ([]string, error) {
 	var matches []string
+	if ignores == nil {
+		ignores = make([]string, 0)
+	}
 
 	file, err := os.Open(path)
 	if err != nil && !os.IsNotExist(err) {
@@ -39,7 +42,7 @@ func Get(path string, ignores ...string) ([]string, error) {
 	}
 
 	for _, ignore := range ignores {
-		ignoreMatches, err := filepath.Glob(filepath.Join(path, "..", ignore))
+		ignoreMatches, err := filepath.Glob(filepath.Join(filepath.Dir(path), ignore))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Ello @sjkaliski, 

Please review the following commits I made in branch 'larzconwell-fix-no-default'.

fe1025a08dd23bffc71e2341881e0c183b1e89c8 (2015-02-05 20:28:35 -0500)
Fix if default ignores are empty.
If no arguments are given to a variadic function the value is nil.

R=@sjkaliski
